### PR TITLE
Bump NAN depdendency to support Node 0.12 through 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "test": "tests"
   },
   "dependencies": {
-    "nan": "~2.1.0"
+    "nan": "~2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "test": "tests"
   },
   "dependencies": {
-    "nan": "~2.6.2"
+    "nan": "~2.6.x"
   }
 }


### PR DESCRIPTION
This allows us to compile on at least Node 6 (current LTS) and theoretically on Node 7 too.